### PR TITLE
Override /subscribe route

### DIFF
--- a/packages/lazarus-shared/routes/index.js
+++ b/packages/lazarus-shared/routes/index.js
@@ -9,6 +9,9 @@ const digitalEdition = require('./digital-edition');
 const websiteSections = require('./website-section');
 
 module.exports = (app) => {
+  // get the site config off the app.
+  const { site } = app.locals;
+
   // Handle submissions on /__inquiry
   loadInquiry(app);
 
@@ -28,7 +31,9 @@ module.exports = (app) => {
   search(app);
 
   // Subscription Pages
-  subscribe(app);
+  if (!site.get('removeSubscribeRoute')) {
+    subscribe(app);
+  }
 
   // Digital Edition Pages
   digitalEdition(app);

--- a/sites/fleetmaintenance.com/config/site.js
+++ b/sites/fleetmaintenance.com/config/site.js
@@ -55,6 +55,7 @@ module.exports = {
   wufoo: {
     userName: 'cygnuscorporate',
   },
+  removeSubscribeRoute: true,
   newsletterSubscribeLink: dragonForms.getFormUrl('newsletterSubscribe'),
   inquiry: {
     // the subject line of the email sent to the brand and/or the company/advertiser


### PR DESCRIPTION
Check for `removeSubscribeRoute` in the site config, which allows a site-specific way to override the /subscribe route in `./lazarus-shared/routes/index.js`.  Kinda hacky, I know.  If we weren’t moving off this platform in the next few months I would do something cleaner, but FM wants a custom subscribe page, and we can’t redirect /subscribe while there’s an active route in `routes/index.js`

With `removeSubscribeRoute = true` in site.config:
<img width="1006" alt="Screen Shot 2020-12-15 at 3 53 27 PM" src="https://user-images.githubusercontent.com/12496550/102279591-46280380-3ef1-11eb-95a7-d99399e32a6b.png">

Without `removeSubscribeRoute` in site.config (or set to false):
<img width="847" alt="Screen Shot 2020-12-15 at 3 50 34 PM" src="https://user-images.githubusercontent.com/12496550/102279624-550eb600-3ef1-11eb-9b3b-73597da801c1.png">
