### PR TITLE
Image embeds alignment correction

### DIFF
--- a/packages/lazarus-shared/scss/_company-page.scss
+++ b/packages/lazarus-shared/scss/_company-page.scss
@@ -1,9 +1,17 @@
 .ldp {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  @media (min-width: 400px) {
+    flex-direction: row;
+    &__logo {
+      img {
+        margin-right: 2rem;
+      }
+    }
+  }
   &__logo {
     img {
-      margin-right: 2rem;
       border: 3px solid #fff;
       border-radius: 100px;
       box-shadow: inset 0 0 5px rgba(0, 0, 0, .5);

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -813,13 +813,6 @@ body {
     min-width: auto;
     max-width: 100%;
   }
-  // temporarily set left/right aligned images like "center"
-  // @todo remove once resolved.
-  &[data-embed-align="left"],
-  &[data-embed-align="right"] {
-    float: none;
-    width: auto;
-  }
 
   &[data-embed-align="left"] {
     margin-right: 0;

--- a/packages/lazarus-shared/theme.scss
+++ b/packages/lazarus-shared/theme.scss
@@ -813,14 +813,6 @@ body {
     min-width: auto;
     max-width: 100%;
   }
-
-  &[data-embed-align="left"] {
-    margin-right: 0;
-  }
-
-  &[data-embed-align="right"] {
-    margin-left: 0;
-  }
 }
 
 .program {


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-386

- Removed css preventing alignment
- Also fixed a mobile issue noticed during testing

Current:
Note -- text is hugging the right side of the container, a longer word would cause an overflow
<img width="424" alt="Screen Shot 2021-01-06 at 11 11 14 AM" src="https://user-images.githubusercontent.com/6343242/103791313-4e66f080-5010-11eb-84d8-8bba49cbd86a.png">

Current desktop embed not aligning per WYSIWYG setting of "right"
<img width="801" alt="Screen Shot 2021-01-06 at 11 18 29 AM" src="https://user-images.githubusercontent.com/6343242/103791822-ea90f780-5010-11eb-8467-38ce1f17c296.png">

Alignment on mobile and tablet will stay the same as current:
<img width="402" alt="Screen Shot 2021-01-06 at 11 10 44 AM" src="https://user-images.githubusercontent.com/6343242/103791285-46a74c00-5010-11eb-84e2-9fb4c41495ec.png">
<img width="738" alt="Screen Shot 2021-01-06 at 11 01 48 AM" src="https://user-images.githubusercontent.com/6343242/103791293-4909a600-5010-11eb-9c87-eef03ed648b2.png">

New:
On small phones...
<img width="383" alt="Screen Shot 2021-01-06 at 11 10 51 AM" src="https://user-images.githubusercontent.com/6343242/103791283-460eb580-5010-11eb-81d7-5bf1ed36a38e.png">

Will look the same as before on larger phones...
<img width="472" alt="Screen Shot 2021-01-06 at 11 15 34 AM" src="https://user-images.githubusercontent.com/6343242/103791583-9be35d80-5010-11eb-81fb-11716378f3db.png">

New embed alignment on desktop sizes:
<img width="795" alt="Screen Shot 2021-01-06 at 11 01 31 AM" src="https://user-images.githubusercontent.com/6343242/103791297-49a23c80-5010-11eb-90e7-abbc9406b3a7.png">


