### PR TITLE
Require `regionCode` and `countryCode` on IdentityX login

### DIFF
--- a/packages/lazarus-shared/identity-x.js
+++ b/packages/lazarus-shared/identity-x.js
@@ -15,6 +15,7 @@ module.exports = (app, startOptions) => {
     const config = new IdentityXConfig({
       requiredServerFields: ['givenName', 'familyName', 'countryCode'],
       requiredClientFields: ['regionCode', 'countryCode'],
+      requiredLoginFields: ['regionCode', 'countryCode'],
       ...options,
       appId,
     });

--- a/packages/lazarus-shared/package.json
+++ b/packages/lazarus-shared/package.json
@@ -18,7 +18,7 @@
     "@base-cms/marko-web-gcse": "^1.37.0",
     "@base-cms/marko-web-gtm": "^1.37.0",
     "@base-cms/marko-web-icons": "^1.37.0",
-    "@base-cms/marko-web-identity-x": "^1.53.0",
+    "@base-cms/marko-web-identity-x": "^1.54.0",
     "@base-cms/marko-web-inquiry": "^1.52.0",
     "@base-cms/marko-web-social-sharing": "^1.47.0",
     "@base-cms/marko-web-theme-default": "^1.41.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,10 +948,10 @@
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web-icons/-/marko-web-icons-1.37.0.tgz#eda757d610836a7e8dc4219b5398488b19982146"
   integrity sha512-4MuM4LZo0hlxOJcyu4xTEGqgdz2xbnIcvyc+O79BM8qeb+23GgtqWVfs15TsQSNT4w6YoJCBCJjb77+EkLi1xg==
 
-"@base-cms/marko-web-identity-x@^1.53.0":
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-identity-x/-/marko-web-identity-x-1.53.0.tgz#9de861f53fb4e3c6618946e14425052c5128b65a"
-  integrity sha512-tajPfOeDUmzipZeyeUqUqIVazsEdBnaUXNltMlFKmgn562+LiP27qtsH+c/lOKam/MqD607UeclYPMHQCsl9YQ==
+"@base-cms/marko-web-identity-x@^1.54.0":
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-identity-x/-/marko-web-identity-x-1.54.0.tgz#2e86a9bf6f32523ab33fc9be3ee3320c4c94c9ba"
+  integrity sha512-pF/Cn73u1QboBwM9lwA2dR5IjP0dVhu9sVAceeWyr1r0HhXHdt86OWbCT77JMsLEvAbB/bzmERDVgv8XDb0IKQ==
   dependencies:
     "@base-cms/object-path" "^1.37.0"
     "@base-cms/utils" "^1.37.0"


### PR DESCRIPTION
Makes `regionCode` and `countryCode` required when a new/unverified user logs in using IdentityX. If a country is selected that also has an enabled regional consent question, that question will also be prompted. This is the website implementation of base-cms/base-cms#509 and, as such, required an upgrade of the `@base-cms/marko-web-identity-x` package