### PR TITLE
Bug fix for /magazines buttons

### DIFF
--- a/packages/lazarus-shared/components/blocks/magazine-publications.marko
+++ b/packages/lazarus-shared/components/blocks/magazine-publications.marko
@@ -1,6 +1,6 @@
 import publicationListFragment from "../../graphql/fragments/magazine-publication-list";
 
-<marko-web-query|{ nodes }| name="magazine-publications" params={ queryFragmet: publicationListFragment }>
+<marko-web-query|{ nodes }| name="magazine-publications" params={ queryFragment: publicationListFragment }>
   <for|publication| of=nodes>
     <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={ publicationId: publication.id }>
       <default-theme-magazine-publication-card-block publication-id=publication.id issue-id=latestIssue.id>

--- a/packages/lazarus-shared/scss/_magazine.scss
+++ b/packages/lazarus-shared/scss/_magazine.scss
@@ -20,4 +20,14 @@
     margin-top: 0;
   }
 
+  // to override packages/lazarus-shared/scss/components/_node.scss setting
+  // not sure what else it would affect, so scoping the override to this block
+  // now match current setting from /@base-cms/marko-web/scss/node.scss
+  &--image-top {
+    #{ $self } {
+      &__image-wrapper + #{ $self }__body {
+        margin-top: .75rem;
+      }
+    }
+  }
 }

--- a/packages/lazarus-shared/scss/_magazine.scss
+++ b/packages/lazarus-shared/scss/_magazine.scss
@@ -24,6 +24,7 @@
   // not sure what else it would affect, so scoping the override to this block
   // now match current setting from /@base-cms/marko-web/scss/node.scss
   .node {
+    $self: &;
     &--image-top {
       #{ $self } {
         &__image-wrapper + #{ $self }__body {

--- a/packages/lazarus-shared/scss/_magazine.scss
+++ b/packages/lazarus-shared/scss/_magazine.scss
@@ -19,15 +19,16 @@
   &--magazine-publication {
     margin-top: 0;
   }
+}
 
-  // to override packages/lazarus-shared/scss/components/_node.scss setting
-  // not sure what else it would affect, so scoping the override to this block
-  // now match current setting from /@base-cms/marko-web/scss/node.scss
+// to override packages/lazarus-shared/scss/components/_node.scss setting
+// not sure what else it would affect, so scoping the override to this block
+// to match current setting from /@base-cms/marko-web/scss/node.scss
+.magazine-publication-card-block {
   .node {
-    $self: &;
     &--image-top {
-      #{ $self } {
-        &__image-wrapper + #{ $self }__body {
+      .node {
+        &__body {
           margin-top: .75rem;
         }
       }

--- a/packages/lazarus-shared/scss/_magazine.scss
+++ b/packages/lazarus-shared/scss/_magazine.scss
@@ -23,10 +23,12 @@
   // to override packages/lazarus-shared/scss/components/_node.scss setting
   // not sure what else it would affect, so scoping the override to this block
   // now match current setting from /@base-cms/marko-web/scss/node.scss
-  &--image-top {
-    #{ $self } {
-      &__image-wrapper + #{ $self }__body {
-        margin-top: .75rem;
+  .node {
+    &--image-top {
+      #{ $self } {
+        &__image-wrapper + #{ $self }__body {
+          margin-top: .75rem;
+        }
       }
     }
   }


### PR DESCRIPTION
- Corrected “queryFragmet” to “queryFragment”
- Added margin-top setting so buttons would display on /magazine pages, instead of hiding behind the magazine image

Current:
<img width="371" alt="Screen Shot 2021-02-10 at 4 58 53 PM" src="https://user-images.githubusercontent.com/6343242/107578286-8d650480-6bc1-11eb-9eb2-b12024c443f7.png">

New:
<img width="376" alt="Screen Shot 2021-02-10 at 4 56 57 PM" src="https://user-images.githubusercontent.com/6343242/107578289-8dfd9b00-6bc1-11eb-950d-b3a081ba3060.png">
