### PR TITLE
Add “Members Only” header to content with label

### DIFF
--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -50,7 +50,7 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
       <@header>
         <@left|{ blockName }|>
           <div class=`${blockName}__sponsored-content`>
-              {{contentLabels}} Content
+              ${contentLabels} Content
           </div>
         </@left>
       </@header>

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -21,6 +21,7 @@ $ const useStickyPromotions = content.type === "promotion" ? blueconic.useSticky
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");
 
 $ const { linkAttrs } = input;
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
 <marko-web-node
   type=`${content.type}-content`
@@ -48,7 +49,9 @@ $ const { linkAttrs } = input;
     <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
       <@header>
         <@left|{ blockName }|>
-          <div class=`${blockName}__sponsored-content`>{{labels}}</div>
+          <div class=`${blockName}__sponsored-content`>
+              {{contentLabels}} Content
+          </div>
         </@left>
       </@header>
     </if>

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -10,18 +10,20 @@ $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = labels.includes("Sponsored");
 $ const isMembersOnly = labels.includes("Members Only");
+$ const isLeaders = labels.includes("Leaders");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
 $ const withMembersOnly = defaultValue(input.withMembersOnly, true);
+$ const withLeaderss = defaultValue(input.withLeaderss, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");
 
 $ const { linkAttrs } = input;
-$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored" || label === "Leaders");
 
 <marko-web-node
   type=`${content.type}-content`
@@ -46,7 +48,11 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
     />
   </if>
   <@body>
-    <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
+    <if(
+      (withSponsored && isSponsored) ||
+      (withMembersOnly && isMembersOnly) ||
+      (withLeaders && isLeaders)
+    )>
       <@header>
         <@left|{ blockName }|>
           <div class=`${blockName}__sponsored-content`>

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -17,7 +17,7 @@ $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
 $ const withMembersOnly = defaultValue(input.withMembersOnly, true);
-$ const withLeaderss = defaultValue(input.withLeaderss, true);
+$ const withLeaders = defaultValue(input.withLeaders, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -5,14 +5,17 @@ import blueconic from "../../blueconic";
 $ const { site } = out.global;
 
 $ const content = getAsObject(input, "node");
+$ const labels = getAsArraay(content, "lables");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
-$ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+$ const isSponsored = labels.includes("Sponsored");
+$ const isMembersOnly = labels.includes("Members Only");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
+$ const withMembersOnly = defaultValue(input.withMembersOnly, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");
@@ -42,10 +45,10 @@ $ const { linkAttrs } = input;
     />
   </if>
   <@body>
-    <if(withSponsored && isSponsored)>
+    <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
       <@header>
         <@left|{ blockName }|>
-          <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+          <div class=`${blockName}__sponsored-content`>{{labels}}</div>
         </@left>
       </@header>
     </if>

--- a/packages/lazarus-shared/components/nodes/content-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-card.marko
@@ -5,7 +5,7 @@ import blueconic from "../../blueconic";
 $ const { site } = out.global;
 
 $ const content = getAsObject(input, "node");
-$ const labels = getAsArraay(content, "lables");
+$ const labels = getAsArray(content, "labels");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = labels.includes("Sponsored");

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -4,8 +4,8 @@ import blueconic from "../../blueconic";
 
 $ const { site } = out.global;
 
-$ const labels = getAsArray(content, "labels");
 $ const content = getAsObject(input, "node");
+$ const labels = getAsArray(content, "labels");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
@@ -46,10 +46,11 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
   </if>
   <@body>
     <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
+      console.log(contentLabels);
       <@header>
         <@left|{ blockName }|>
           <div class=`${blockName}__sponsored-content`>
-              {{contentLabels}} Content
+              ${contentLabels} Content
           </div>
         </@left>
       </@header>

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -8,7 +8,7 @@ $ const content = getAsObject(input, "node");
 $ const labels = getAsArray(content, "labels");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
-$ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+$ const isSponsored = labels.includes("Sponsored");
 $ const isMembersOnly = labels.includes("Members Only");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
@@ -46,7 +46,6 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
   </if>
   <@body>
     <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
-      console.log(contentLabels);
       <@header>
         <@left|{ blockName }|>
           <div class=`${blockName}__sponsored-content`>

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -10,18 +10,20 @@ $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = labels.includes("Sponsored");
 $ const isMembersOnly = labels.includes("Members Only");
+$ const isLeaders = labels.includes("Leaders");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
 $ const withMembersOnly = defaultValue(input.withMembersOnly, true);
+$ const withLeaderss = defaultValue(input.withLeaderss, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");
 
 $ const { linkAttrs } = input;
-$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored" || label === "Leaders");
 
 <marko-web-node
   type=`${content.type}-content`
@@ -45,7 +47,11 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
     />
   </if>
   <@body>
-    <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
+    <if(
+      (withSponsored && isSponsored) ||
+      (withMembersOnly && isMembersOnly) ||
+      (withLeaders && isLeaders)
+    )>
       <@header>
         <@left|{ blockName }|>
           <div class=`${blockName}__sponsored-content`>

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -17,7 +17,7 @@ $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
 $ const withMembersOnly = defaultValue(input.withMembersOnly, true);
-$ const withLeaderss = defaultValue(input.withLeaderss, true);
+$ const withLeaders = defaultValue(input.withLeaders, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");

--- a/packages/lazarus-shared/components/nodes/content-list.marko
+++ b/packages/lazarus-shared/components/nodes/content-list.marko
@@ -4,20 +4,24 @@ import blueconic from "../../blueconic";
 
 $ const { site } = out.global;
 
+$ const labels = getAsArray(content, "labels");
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+$ const isMembersOnly = labels.includes("Members Only");
 
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const withSection = defaultValue(input.withSection, true);
 $ const withDates = defaultValue(input.withDates, true);
 $ const withSponsored = defaultValue(input.withSponsored, true);
+$ const withMembersOnly = defaultValue(input.withMembersOnly, true);
 
 $ const useStickyPromotions = content.type === "promotion" ? blueconic.useStickyPromotions({ site, promotion: content }) : false;
 $ const href = useStickyPromotions ? get(content, "promotionContext.path") : get(content, "siteContext.path");
 
 $ const { linkAttrs } = input;
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
 <marko-web-node
   type=`${content.type}-content`
@@ -41,10 +45,12 @@ $ const { linkAttrs } = input;
     />
   </if>
   <@body>
-    <if(withSponsored && isSponsored)>
+    <if((withSponsored && isSponsored) || (withMembersOnly && isMembersOnly))>
       <@header>
         <@left|{ blockName }|>
-          <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+          <div class=`${blockName}__sponsored-content`>
+              {{contentLabels}} Content
+          </div>
         </@left>
       </@header>
     </if>

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -5,8 +5,8 @@ import imageHeight from "@base-cms/marko-web/components/node/utils/image-height"
 
 $ const blockName = "content-page-card";
 
-$ const labels = getAsArray(content, "labels");
 $ const content = getAsObject(input, "content");
+$ const labels = getAsArray(content, "labels");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
@@ -61,7 +61,7 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
     <marko-web-node-element name="header-body" modifiers=[type] block-name=blockName>
       <if( isSponsored || isMembersOnly)>
         <div class=`${blockName}__sponsored-content`>
-            {{contentLabels}} Content
+            ${contentLabels} Content
         </div>
       </if>
 

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -11,6 +11,7 @@ $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
 $ const isMembersOnly = labels.includes("Members Only");
+$ const isLeaders = labels.includes("Leaders");
 
 $ const { type } = content;
 
@@ -29,7 +30,7 @@ $ const hasEmbedCode = Boolean(content.embedCode);
 $ const displayPrimaryImage = !hasEmbedCode && hasImage && type !== "media-gallery" && !isLogo;
 $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
 
-$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored" || label === "Leaders");
 
 <!-- @todo add lower-right image caption -->
 <marko-web-block
@@ -59,7 +60,7 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
       </marko-web-node-element>
     </if>
     <marko-web-node-element name="header-body" modifiers=[type] block-name=blockName>
-      <if( isSponsored || isMembersOnly)>
+      <if( isSponsored || isMembersOnly || isLeaders)>
         <div class=`${blockName}__sponsored-content`>
             ${contentLabels} Content
         </div>

--- a/packages/lazarus-shared/components/nodes/content-page-card.marko
+++ b/packages/lazarus-shared/components/nodes/content-page-card.marko
@@ -5,10 +5,12 @@ import imageHeight from "@base-cms/marko-web/components/node/utils/image-height"
 
 $ const blockName = "content-page-card";
 
+$ const labels = getAsArray(content, "labels");
 $ const content = getAsObject(input, "content");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+$ const isMembersOnly = labels.includes("Members Only");
 
 $ const { type } = content;
 
@@ -26,6 +28,8 @@ $ const hasEmbedCode = Boolean(content.embedCode);
 
 $ const displayPrimaryImage = !hasEmbedCode && hasImage && type !== "media-gallery" && !isLogo;
 $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
+
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
 <!-- @todo add lower-right image caption -->
 <marko-web-block
@@ -55,9 +59,12 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
       </marko-web-node-element>
     </if>
     <marko-web-node-element name="header-body" modifiers=[type] block-name=blockName>
-      <if(isSponsored)>
-        <div class=`${blockName}__sponsored-content`>Sponsored Content</div>
+      <if( isSponsored || isMembersOnly)>
+        <div class=`${blockName}__sponsored-content`>
+            {{contentLabels}} Content
+        </div>
       </if>
+
       <default-theme-website-section-breadcrumbs
         section=primarySection
         display-home=false

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -29,6 +29,7 @@
     "@with-section": "boolean",
     "@with-dates": "boolean",
     "@with-sponsored": "boolean",
+    "@with-members-only": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -11,6 +11,7 @@
     "@with-section": "boolean",
     "@with-dates": "boolean",
     "@with-sponsored": "boolean",
+    "@with-members-only": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",

--- a/packages/lazarus-shared/components/nodes/marko.json
+++ b/packages/lazarus-shared/components/nodes/marko.json
@@ -12,6 +12,7 @@
     "@with-dates": "boolean",
     "@with-sponsored": "boolean",
     "@with-members-only": "boolean",
+    "@with-leaders": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",
@@ -30,6 +31,7 @@
     "@with-dates": "boolean",
     "@with-sponsored": "boolean",
     "@with-members-only": "boolean",
+    "@with-leaders": "boolean",
 
     "@modifiers": "array",
     "@attrs": "object",

--- a/packages/lazarus-shared/templates/content/print.marko
+++ b/packages/lazarus-shared/templates/content/print.marko
@@ -58,13 +58,14 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
         $ const labels = getAsArray(content, "labels");
         $ const isSponsored = labels.includes("Sponsored");
         $ const isMembersOnly = labels.includes("Members Only");
+        $ const isLeaders = labels.includes("Leaders");
 
-        $ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
+        $ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored" || label === "Leaders");
 
         <default-theme-page-contents|{ blockName: contentsBlock }|>
           <marko-web-identity-x-access|context| enabled=true>
             <if(!context.canAccess || context.requiresUserInput)>
-              <if( isSponsored || isMembersOnly)>
+              <if( isSponsored || isMembersOnly || isLeaders)>
                 <div class=`${blockName}__sponsored-content`>
                     ${contentLabels} Content
                 </div>
@@ -119,7 +120,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
                 </div>
               </if>
 
-              <if( isSponsored || isMembersOnly)>
+              <if( isSponsored || isMembersOnly || isLeaders)>
                 <div class=`${blockName}__sponsored-content`>
                     ${contentLabels} Content
                 </div>

--- a/packages/lazarus-shared/templates/content/print.marko
+++ b/packages/lazarus-shared/templates/content/print.marko
@@ -7,7 +7,6 @@ $ const { site, config, req } = out.global;
 
 $ const cardBlock = "content-page-card";
 $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
-$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
 <marko-web-document>
   <@head>
@@ -55,16 +54,19 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
 
         $ const src = buildImgixUrl(primaryImage.src, { w: imgWidth, h: imgHeight, fit: "crop" });
         $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
+        $ const content = getAsObject(input, "node");
         $ const labels = getAsArray(content, "labels");
         $ const isSponsored = labels.includes("Sponsored");
         $ const isMembersOnly = labels.includes("Members Only");
+
+        $ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
         <default-theme-page-contents|{ blockName: contentsBlock }|>
           <marko-web-identity-x-access|context| enabled=true>
             <if(!context.canAccess || context.requiresUserInput)>
               <if( isSponsored || isMembersOnly)>
                 <div class=`${blockName}__sponsored-content`>
-                    {{contentLabels}} Content
+                    ${contentLabels} Content
                 </div>
               </if>
               <default-theme-website-section-breadcrumbs
@@ -119,7 +121,7 @@ $ const contentLabels = labels.filter(label => label === "Members Only" || label
 
               <if( isSponsored || isMembersOnly)>
                 <div class=`${blockName}__sponsored-content`>
-                    {{contentLabels}} Content
+                    ${contentLabels} Content
                 </div>
               </if>
               <default-theme-website-section-breadcrumbs

--- a/packages/lazarus-shared/templates/content/print.marko
+++ b/packages/lazarus-shared/templates/content/print.marko
@@ -7,6 +7,7 @@ $ const { site, config, req } = out.global;
 
 $ const cardBlock = "content-page-card";
 $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includes(type) ? false : true;
+$ const contentLabels = labels.filter(label => label === "Members Only" || label === "Sponsored");
 
 <marko-web-document>
   <@head>
@@ -54,14 +55,17 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
 
         $ const src = buildImgixUrl(primaryImage.src, { w: imgWidth, h: imgHeight, fit: "crop" });
         $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
-
-        $ const isSponsored = getAsArray(content, "labels").includes("Sponsored");
+        $ const labels = getAsArray(content, "labels");
+        $ const isSponsored = labels.includes("Sponsored");
+        $ const isMembersOnly = labels.includes("Members Only");
 
         <default-theme-page-contents|{ blockName: contentsBlock }|>
           <marko-web-identity-x-access|context| enabled=true>
             <if(!context.canAccess || context.requiresUserInput)>
-              <if(isSponsored)>
-                <div class=`${cardBlock}__sponsored-content`>Sponsored Content</div>
+              <if( isSponsored || isMembersOnly)>
+                <div class=`${blockName}__sponsored-content`>
+                    {{contentLabels}} Content
+                </div>
               </if>
               <default-theme-website-section-breadcrumbs
                 section=primarySection
@@ -113,8 +117,10 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
                 </div>
               </if>
 
-              <if(isSponsored)>
-                <div class=`${cardBlock}__sponsored-content`>Sponsored Content</div>
+              <if( isSponsored || isMembersOnly)>
+                <div class=`${blockName}__sponsored-content`>
+                    {{contentLabels}} Content
+                </div>
               </if>
               <default-theme-website-section-breadcrumbs
                 section=primarySection


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-542

Added "Members Only Content" header to items with "Members Only" label, and "Leaders Content" header to items with "Leaders" label., using the same settings as items using the "Sponsored Content" header for "Sponsored" label.

Examples with content from https://manage.electronicdesign.com/content/edit/whitepaper/21154985 / https://www.electronicdesign.com/members / http://0.0.0.0:5718/members/ebook-library/whitepaper/21154985/bob-pease-ebook-vol-2-download
![Screen Shot 2021-02-25 at 3 35 48 PM](https://user-images.githubusercontent.com/6343242/109213971-40fff400-777f-11eb-9ecf-47a74a053c56.png)
![Screen Shot 2021-02-25 at 3 35 33 PM](https://user-images.githubusercontent.com/6343242/109213974-41988a80-777f-11eb-9054-331e972d8b6d.png)

Had to temporarily add the "Leaders" label to the preview content below, because I couldn't find an article on the sites I checked with a Leaders label.
![Screen Shot 2021-02-25 at 4 09 52 PM](https://user-images.githubusercontent.com/6343242/109217492-ea48e900-7783-11eb-8508-9327fe80bd58.png)
![Screen Shot 2021-02-25 at 4 08 58 PM](https://user-images.githubusercontent.com/6343242/109217495-eae17f80-7783-11eb-801d-50b672f4b776.png)
![Screen Shot 2021-02-25 at 4 07 40 PM](https://user-images.githubusercontent.com/6343242/109217498-eb7a1600-7783-11eb-8ff9-fb9318bf8a37.png)
