### PR TITLE
Update `content/print.marko`

### DIFF
--- a/packages/lazarus-shared/templates/content/print.marko
+++ b/packages/lazarus-shared/templates/content/print.marko
@@ -24,6 +24,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
     </marko-web-gtm-content-context>
     <marko-web-gtm-start />
   </@head>
+
   <@above-container>
     <div class="container p-5 bg-white">
       <div class="row mb-block">
@@ -54,7 +55,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact", "company"].includ
 
         $ const src = buildImgixUrl(primaryImage.src, { w: imgWidth, h: imgHeight, fit: "crop" });
         $ const srcset = [`${buildImgixUrl(src, { dpr: 2 })} 2x`];
-        $ const content = getAsObject(input, "node");
+        $ const blockName = "page-contents";
         $ const labels = getAsArray(content, "labels");
         $ const isSponsored = labels.includes("Sponsored");
         $ const isMembersOnly = labels.includes("Members Only");


### PR DESCRIPTION
Remove `const content` as that’s already been defined, added `const blockName` as that wasn’t being passed previously.

Gated print:
<img width="994" alt="Screen Shot 2021-03-16 at 11 20 53 AM" src="https://user-images.githubusercontent.com/12496550/111344315-4350c200-864a-11eb-8c13-8881d5b2f47d.png">

else:
<img width="871" alt="Screen Shot 2021-03-16 at 11 22 14 AM" src="https://user-images.githubusercontent.com/12496550/111344323-477cdf80-864a-11eb-91ad-2c4548d5f6a5.png">
